### PR TITLE
Make the SapSolver Cache a little safer

### DIFF
--- a/multibody/contact_solvers/sap_solver.cc
+++ b/multibody/contact_solvers/sap_solver.cc
@@ -3,8 +3,6 @@
 #include <algorithm>
 #include <vector>
 
-#include "fmt/format.h"
-
 #include "drake/multibody/contact_solvers/contact_solver_utils.h"
 
 namespace drake {
@@ -13,13 +11,153 @@ namespace contact_solvers {
 namespace internal {
 
 template <typename T>
-ContactSolverStatus SapSolver<T>::SolveWithGuess(const T&,
-                                                 const SystemDynamicsData<T>&,
-                                                 const PointContactData<T>&,
-                                                 const VectorX<T>&,
-                                                 ContactSolverResults<T>*) {
-  throw std::logic_error("This method must be implemented.");
-  DRAKE_UNREACHABLE();
+void SapSolver<T>::Cache::Resize(int nv, int nc) {
+  velocities_cache_.Resize(nc);
+  momentum_cache_.Resize(nv);
+  impulses_cache_.Resize(nc);
+  gradients_cache_.Resize(nv, nc);
+  search_direction_cache_.Resize(nv, nc);
+}
+
+template <typename T>
+ContactSolverStatus SapSolver<T>::SolveWithGuess(
+    const T& time_step, const SystemDynamicsData<T>& dynamics_data,
+    const PointContactData<T>& contact_data, const VectorX<T>& v_guess,
+    ContactSolverResults<T>* results) {
+  // The primal method needs the inverse dynamics data.
+  DRAKE_DEMAND(dynamics_data.has_inverse_dynamics());
+  // User code should only call the solver for problems with constraints.
+  // Otherwise the solution is trivially v = v*.
+  DRAKE_DEMAND(contact_data.num_contacts() != 0);
+  data_ = PreProcessData(time_step, dynamics_data, contact_data);
+  return DoSolveWithGuess(v_guess, results);
+}
+
+template <typename T>
+Vector3<T> SapSolver<T>::ProjectSingleImpulse(
+    const T& mu, const Eigen::Ref<const Vector3<T>>& R,
+    const Eigen::Ref<const Vector3<T>>& y, Matrix3<T>* dPdy) const {
+  // Computes the "soft norm" ‖x‖ₛ defined by ‖x‖ₛ² = ‖x‖² + ε², where ε =
+  // soft_tolerance. Using the soft norm we define the tangent vector as t̂ =
+  // γₜ/‖γₜ‖ₛ, which is well defined even for γₜ = 0. Also gradients are well
+  // defined and follow the same equations presented in [Castro et al., 2021]
+  // where regular norms are simply replaced by soft norms.
+  auto soft_norm = [eps = parameters_.soft_tolerance](
+                       const Eigen::Ref<const VectorX<T>>& x) -> T {
+    using std::sqrt;
+    return sqrt(x.squaredNorm() + eps * eps);
+  };
+
+  // We assume a regularization of the form R = (Rt, Rt, Rn).
+  const T& Rt = R(0);
+  const T& Rn = R(2);
+  const T mu_hat = mu * Rt / Rn;
+
+  const auto yt = y.template head<2>();
+  const T yr = soft_norm(yt);
+  const T yn = y(2);
+  const Vector2<T> t_hat = yt / yr;
+
+  // N.B. The expressions implemented below are also valid for mu = 0. The
+  // projection below reduces to gamma = [0, 0, max(0, yn)] when mu = 0, as it
+  // should. The gradient also reduces to the correct expression:
+  //     | 0 0 0 |
+  // G = | 0 0 0 |
+  //     | 0 0 1 |
+
+  Vector3<T> gamma;
+  // Analytical projection of y onto the friction cone ℱ using the R norm.
+  if (yr < mu * yn) {
+    // Region I, stiction.
+    gamma = y;
+    if (dPdy) dPdy->setIdentity();
+  } else if (-mu_hat * yr < yn && mu * yn <= yr) {
+    // Region II, sliding.
+
+    // Common terms in both the projection and its gradient.
+    const T mu_tilde_squared = mu * mu_hat;  // mu_tilde = mu * sqrt(Rt/Rn).
+    const T factor = 1.0 / (1.0 + mu_tilde_squared);
+
+    // Projection P(y).
+    const T gn = (yn + mu_hat * yr) * factor;
+    const Vector2<T> gt = mu * gn * t_hat;
+    gamma.template head<2>() = gt;
+    gamma(2) = gn;
+
+    // Gradient.
+    if (dPdy) {
+      const Matrix2<T> P = t_hat * t_hat.transpose();
+      const Matrix2<T> Pperp = Matrix2<T>::Identity() - P;
+
+      // We split dPdy into separate blocks:
+      //
+      // dPdy = |dgt_dyt dgt_dyn|
+      //        |dgn_dyt dgn_dyn|
+      // where dgt_dyt ∈ ℝ²ˣ², dgt_dyn ∈ ℝ², dgn_dyt ∈ ℝ²ˣ¹ and dgn_dyn ∈ ℝ.
+      const Matrix2<T> dgt_dyt = mu * (gn / yr * Pperp + mu_hat * factor * P);
+      const Vector2<T> dgt_dyn = mu * factor * t_hat;
+      const RowVector2<T> dgn_dyt = mu_hat * factor * t_hat.transpose();
+      const T dgn_dyn = factor;
+
+      dPdy->template topLeftCorner<2, 2>() = dgt_dyt;
+      dPdy->template topRightCorner<2, 1>() = dgt_dyn;
+      dPdy->template bottomLeftCorner<1, 2>() = dgn_dyt;
+      (*dPdy)(2, 2) = dgn_dyn;
+    }
+  } else {  // yn <= -mu_hat * yr
+    // Region III, no contact.
+    gamma.setZero();
+    if (dPdy) dPdy->setZero();
+  }
+
+  return gamma;
+}
+
+template <typename T>
+void SapSolver<T>::ProjectAllImpulses(const VectorX<T>& y,
+                                      VectorX<T>* gamma) const {
+  const int nc = data_.nc;
+  const int nc3 = 3 * nc;
+  DRAKE_DEMAND(y.size() == nc3);
+  DRAKE_DEMAND(gamma->size() == nc3);
+
+  // Data.
+  const auto& R = data_.R;
+  const auto& mu = data_.mu;
+
+  for (int ic = 0; ic < nc; ++ic) {
+    const int ic3 = 3 * ic;
+    const auto& R_ic = R.template segment<3>(ic3);
+    const T& mu_ic = mu(ic);
+    const auto& y_ic = y.template segment<3>(ic3);
+    // Analytical projection of y onto the friction cone ℱ using the R norm.
+    gamma->template segment<3>(ic3) =
+        ProjectSingleImpulse(mu_ic, R_ic, y_ic);
+  }
+}
+
+template <typename T>
+void SapSolver<T>::CalcAllProjectionsGradients(
+    const VectorX<T>& y, std::vector<Matrix3<T>>* dPdy) const {
+  const int nc = data_.nc;
+  const int nc3 = 3 * nc;
+  DRAKE_DEMAND(y.size() == nc3);
+  DRAKE_DEMAND(static_cast<int>(dPdy->size()) == nc);
+
+  // Data.
+  const auto& R = data_.R;
+  const auto& mu = data_.mu;
+
+  for (int ic = 0; ic < nc; ++ic) {
+    const int ic3 = 3 * ic;
+    const auto& R_ic = R.template segment<3>(ic3);
+    const T& mu_ic = mu(ic);
+    const auto& y_ic = y.template segment<3>(ic3);
+
+    // Analytical projection of y onto the friction cone ℱ using the R norm.
+    auto& dPdy_ic = (*dPdy)[ic];
+    ProjectSingleImpulse(mu_ic, R_ic, y_ic, &dPdy_ic);
+  }
 }
 
 template <typename T>
@@ -119,8 +257,8 @@ typename SapSolver<T>::PreProcessedData SapSolver<T>::PreProcessData(
   // We use the Delassus scaling computed above to estimate regularization
   // parameters in the matrix R.
   const VectorX<T>& delassus_diagonal = data.delassus_diagonal;
-  const double beta = parameters().beta;
-  const double sigma = parameters().sigma;
+  const double beta = parameters_.beta;
+  const double sigma = parameters_.sigma;
 
   // Rigid approximation constant: Rₙ = β²/(4π²)⋅wᵢ when the contact frequency
   // ωₙ is below the limit ωₙ⋅δt ≤ 2π. That is, the period is Tₙ = β⋅δt. See
@@ -169,6 +307,386 @@ void SapSolver<T>::PackContactResults(const PreProcessedData& data,
   results->ft /= data.time_step;
   data.J.MultiplyByTranspose(gamma, &results->tau_contact);
   results->tau_contact /= data.time_step;
+}
+
+template <typename T>
+void SapSolver<T>::CalcStoppingCriteriaResidual(const State& state,
+                                                T* momentum_residual,
+                                                T* momentum_scale) const {
+  using std::max;
+  const auto& inv_sqrt_A = data_.inv_sqrt_A;
+  const auto& momentum_cache = EvalMomentumCache(state);
+  const VectorX<T>& p = momentum_cache.p;
+  const VectorX<T>& jc = momentum_cache.jc;
+  const VectorX<T>& ell_grad = EvalGradientsCache(state).ell_grad_v;
+
+  // Scale generalized momentum quantities using inv_sqrt_A so that all entries
+  // have the same units and we can weigh them equally.
+  const VectorX<T> ell_grad_tilde = inv_sqrt_A.asDiagonal() * ell_grad;
+  const VectorX<T> p_tilde = inv_sqrt_A.asDiagonal() * p;
+  const VectorX<T> jc_tilde = inv_sqrt_A.asDiagonal() * jc;
+
+  *momentum_residual = ell_grad_tilde.norm();
+  *momentum_scale = max(p_tilde.norm(), jc_tilde.norm());
+}
+
+template <typename T>
+ContactSolverStatus SapSolver<T>::DoSolveWithGuess(
+    const VectorX<T>& v_guess, ContactSolverResults<T>* result) {
+  throw std::logic_error("Only T = double is supported.");
+}
+
+template <>
+ContactSolverStatus SapSolver<double>::DoSolveWithGuess(
+    const VectorX<double>& v_guess, ContactSolverResults<double>* results) {
+  using std::abs;
+  using std::max;
+
+  const int nv = data_.nv;
+  const int nc = data_.nc;
+  State state(nv, nc);
+  stats_.Reset();
+
+  state.mutable_v() = v_guess;
+
+  // Start Newton iterations.
+  int k = 0;
+  double ell_previous = EvalCostCache(state).ell;
+  bool converged = false;
+  for (;; ++k) {
+    // We first verify the stopping criteria. If satisfied, we skip expensive
+    // factorizations.
+    double momentum_residual, momentum_scale;
+    CalcStoppingCriteriaResidual(state, &momentum_residual, &momentum_scale);
+
+    if (momentum_residual <= parameters_.abs_tolerance +
+                                 parameters_.rel_tolerance * momentum_scale) {
+      converged = true;
+      break;
+    } else {
+      // TODO(amcastro-tri): Instantiate supernodal solver on the first
+      // iteration if it is needed. If the stopping criteria is satisfied at k =
+      // 0 (good guess), then we skip the expensive instantiation of the solver.
+    }
+
+    // Exit if the maximum number of iterations is reached, but only after
+    // checking the convergence criteria, so that also the last iteration is
+    // considered.
+    if (k == parameters_.max_iterations) break;
+
+    // This is the most expensive update: it performs the factorization of H to
+    // solve for the search direction dv.
+    const VectorX<double>& dv = EvalSearchDirectionCache(state).dv;
+
+    int ls_iters;
+    const double alpha = PerformBackTrackingLineSearch(state, dv, &ls_iters);
+    stats_.num_line_search_iters += ls_iters;
+
+    // Update state.
+    state.mutable_v() += alpha * dv;
+
+    // Verify the cost decreases on each iteration.
+    const double ell = EvalCostCache(state).ell;
+    // TODO(amcastro-tri): sometimes this demand is triggered due to round-off
+    // errors. Consider:
+    //  1. Verify this condition with a slop, i.e. ell < ell_previous + slop.
+    //  2. Update stopping criterion to also include a tolerance on the cost,
+    //     i.e. 2. * |ell-ell_previous|/(ell + ell_previous) < cost_tolerance.
+    DRAKE_DEMAND(ell < ell_previous);
+    ell_previous = ell;
+  }
+
+  if (!converged) return ContactSolverStatus::kFailure;
+
+  const VectorX<double>& vc = EvalVelocitiesCache(state).vc;
+  const VectorX<double>& gamma = EvalImpulsesCache(state).gamma;
+  PackContactResults(data_, state.v(), vc, gamma, results);
+
+  // N.B. If the stopping criteria is satisfied for k = 0, the solver is not
+  // even instantiated and no factorizations are performed (the expensive part
+  // of the computation). We report zero number of iterations.
+  stats_.num_iters = k;
+
+  return ContactSolverStatus::kSuccess;
+}
+
+template <typename T>
+T SapSolver<T>::CalcLineSearchCost(const State& state_v, const T& alpha,
+                                   State* state_alpha) const {
+  // Data.
+  const VectorX<T>& R = data_.R;
+  const VectorX<T>& v_star = data_.v_star;
+
+  // Cached quantities at state v.
+  const typename Cache::SearchDirectionCache& search_direction_cache =
+      EvalSearchDirectionCache(state_v);
+  const VectorX<T>& dv = search_direction_cache.dv;
+  const VectorX<T>& dp = search_direction_cache.dp;
+  const T& d2ellA_dalpha2 = search_direction_cache.d2ellA_dalpha2;
+
+  // State at v(alpha).
+  state_alpha->mutable_v() = state_v.v() + alpha * dv;
+
+  // Update velocities and impulses at v(alpha).
+  const VectorX<T>& gamma = EvalImpulsesCache(*state_alpha).gamma;
+
+  // Regularizer cost.
+  const T ellR = 0.5 * gamma.dot(R.asDiagonal() * gamma);
+
+  // Momentum cost. We use the O(n) strategy described in [Castro et al., 2021].
+  // The momentum cost is: ellA(α) = 0.5‖v(α)−v*‖², where ‖⋅‖ is the norm
+  // defined by A. v(α) corresponds to the value of v along the search
+  // direction: v(α) = v + αΔv. Using v(α) in the expression of the cost and
+  // expanding the squared norm leads to: ellA(α) = 0.5‖v−v*‖² + αΔvᵀ⋅A⋅(v−v*) +
+  // 0.5‖Δv‖²α². We now notice some of those terms are already cached:
+  //  - dpᵀ = Δvᵀ⋅A
+  //  - ellA(v) = 0.5‖v−v*‖²
+  //  - d2ellA_dalpha2 = 0.5‖Δv‖²α², see [Castro et al., 2021; §VIII.C].
+  T ellA = EvalCostCache(state_v).ellA;
+  ellA += alpha * dp.dot(state_v.v() - v_star);
+  ellA += 0.5 * alpha * alpha * d2ellA_dalpha2;
+  const T ell = ellA + ellR;
+
+  return ell;
+}
+
+template <typename T>
+T SapSolver<T>::PerformBackTrackingLineSearch(
+    const State& state, const VectorX<T>& dv, int* num_iterations) const {
+  // Line search parameters.
+  const double rho = parameters_.ls_rho;
+  const double c = parameters_.ls_c;
+  const int max_iterations = parameters_.ls_max_iterations;
+
+  // Quantities at alpha = 0.
+  const T& ell0 = EvalCostCache(state).ell;
+  const auto& ell_grad_v0 = EvalGradientsCache(state).ell_grad_v;
+
+  // dℓ/dα(α = 0) = ∇ᵥℓ(α = 0)⋅Δv.
+  const T dell_dalpha0 = ell_grad_v0.dot(dv);
+
+  // dℓ/dα(α = 0) is guaranteed to be strictly negative given the the Hessian of
+  // the cost is positive definite. Only round-off errors in the factorization
+  // of the Hessian for ill-conditioned systems (small regularization) can
+  // destroy this property. If so, we abort given that'd mean the model must be
+  // revisited.
+  if (dell_dalpha0 >= 0) {
+    throw std::runtime_error(
+        "The cost does not decrease along the search direction. This is "
+        "usually caused by an excessive accumulation round-off errors for "
+        "ill-conditioned systems. Consider revisiting your model.");
+  }
+
+  T alpha = parameters_.ls_alpha_max;
+  // TODO(amcastro-tri): Consider removing this heap allocation from this scope.
+  State state_aux(state);  // Auxiliary workspace.
+  T ell = CalcLineSearchCost(state, alpha, &state_aux);
+
+  // Verifies if ell(alpha) satisfies Armijo's criterion.
+  auto satisfies_armijo = [c, ell0, dell_dalpha0](const T& alpha_in,
+                                                  const T& ell_in) {
+    return ell_in < ell0 + c * alpha_in * dell_dalpha0;
+  };
+
+  // Initialize previous iteration values.
+  T alpha_prev = alpha;
+  T ell_prev = ell;
+
+  int iteration = 1;
+  for (; iteration <= max_iterations; ++iteration) {
+    alpha *= rho;
+    ell = CalcLineSearchCost(state, alpha, &state_aux);
+    // We scan discrete values of alpha from alpha_max to zero and seek for the
+    // minimum value of the cost evaluated at those discrete values. Since we
+    // know the cost is convex, we detect this minimum by checking the condition
+    // ell > ell_prev. If Armijo's criterion is satisfied, we are done.
+    // Otherwise we continue iterating until Armijo's criterion is satisfied.
+    // N.B. Armijo's criterion allows to prove convergence. Therefore we want
+    // the search parameter to satisfy it.
+    if (ell > ell_prev && satisfies_armijo(alpha, ell)) {
+      // The previous iteration is better if it satisfies Armijo's
+      // criterion since in this scope ell_prev < ell. If so, we
+      // backtrack to the previous iteration.
+      if (satisfies_armijo(alpha_prev, ell_prev)) alpha /= rho;
+      *num_iterations = iteration;
+      return alpha;
+    }
+    alpha_prev = alpha;
+    ell_prev = ell;
+  }
+
+  // If we are here, the line-search could not find a valid parameter that
+  // satisfies Armijo's criterion.
+  throw std::runtime_error(
+      "Line search reached the maximum number of iterations. Either we need to "
+      "increase the maximum number of iterations parameter or to condition the "
+      "problem better.");
+
+  // Silence "no-return value" warning from the compiler.
+  DRAKE_UNREACHABLE();
+}
+
+template <typename T>
+void SapSolver<T>::CallDenseSolver(const State& state, VectorX<T>* dv) const {
+  const auto& gradients_cache = EvalGradientsCache(state);
+  // Explicitly build dense Hessian.
+  // These matrices could be saved in the cache. However this method is only
+  // intended as an alternative for debugging and optimizing it might not be
+  // worth it.
+  const int nv = data_.nv;
+  MatrixX<T> H(nv, nv);
+  {
+    const int nc = data_.nc;
+    const auto& A = data_.A;
+    const auto& J = data_.J;
+    const auto& G = gradients_cache.G;
+
+    const MatrixX<T> Jdense = J.MakeDenseMatrix();
+    MatrixX<T> Adense(nv, nv);
+    Adense = A.MakeDenseMatrix();
+
+    MatrixX<T> GJ(3 * nc, nv);
+    for (int ic = 0; ic < nc; ++ic) {
+      const int ic3 = 3 * ic;
+      const MatrixX<T>& G_ic = G[ic];
+      GJ.template middleRows<3>(ic3) =
+          G_ic * Jdense.template middleRows<3>(ic3);
+    }
+    H = Adense + Jdense.transpose() * GJ;
+  }
+
+  // Factorize Hessian.
+  // TODO(amcastro-tri): Make use of mat::SolveLinearSystem() for a quick and
+  // dirty way to support AutoDiffXd, at least to build unit tests.
+  const Eigen::LDLT<MatrixX<T>> Hldlt(H);
+  if (Hldlt.info() != Eigen::Success) {
+    throw std::runtime_error("Dense LDLT factorization of the Hessian failed.");
+  }
+
+  // Compute search direction.
+  const VectorX<T> rhs = -gradients_cache.ell_grad_v;
+  *dv = Hldlt.solve(rhs);
+}
+
+template <typename T>
+const typename SapSolver<T>::Cache::VelocitiesCache&
+SapSolver<T>::EvalVelocitiesCache(const State& state) const {
+  if (state.cache().velocities_cache().valid)
+    return state.cache().velocities_cache();
+  typename Cache::VelocitiesCache& cache =
+      state.mutable_cache().mutable_velocities_cache();
+  const auto& Jc = data_.J;
+  Jc.Multiply(state.v(), &cache.vc);
+  cache.valid = true;
+  return cache;
+}
+
+template <typename T>
+const typename SapSolver<T>::Cache::ImpulsesCache&
+SapSolver<T>::EvalImpulsesCache(const State& state) const {
+  if (state.cache().impulses_cache().valid)
+    return state.cache().impulses_cache();
+  typename Cache::ImpulsesCache& cache =
+      state.mutable_cache().mutable_impulses_cache();
+  const VectorX<T>& vc = EvalVelocitiesCache(state).vc;
+  const VectorX<T>& Rinv = data_.Rinv;
+  const VectorX<T>& vhat = data_.vhat;
+  cache.y = vhat - vc;
+  // The (unprojected) impulse y=−R⁻¹⋅(vc − v̂).
+  cache.y.array() *= Rinv.array();
+  ProjectAllImpulses(cache.y, &cache.gamma);
+  ++stats_.num_impulses_cache_updates;
+  cache.valid = true;
+  return cache;
+}
+
+template <typename T>
+const typename SapSolver<T>::Cache::MomentumCache&
+SapSolver<T>::EvalMomentumCache(const State& state) const {
+  if (state.cache().momentum_cache().valid)
+    return state.cache().momentum_cache();
+  typename Cache::MomentumCache& cache =
+      state.mutable_cache().mutable_momentum_cache();
+  data_.A.Multiply(state.v(), &cache.p);  // p = A⋅v.
+  const VectorX<T>& gamma = EvalImpulsesCache(state).gamma;
+  data_.J.MultiplyByTranspose(gamma, &cache.jc);
+  // = p - p* = A⋅(v−v*).
+  cache.momentum_change = cache.p - data_.p_star;
+  cache.valid = true;
+  return cache;
+}
+
+template <typename T>
+const typename SapSolver<T>::Cache::CostCache& SapSolver<T>::EvalCostCache(
+    const State& state) const {
+  if (state.cache().cost_cache().valid) return state.cache().cost_cache();
+  typename Cache::CostCache& cache =
+      state.mutable_cache().mutable_cost_cache();
+  const auto& R = data_.R;
+  const auto& v_star = data_.v_star;
+  const VectorX<T>& v = state.v();
+  const VectorX<T>& gamma = EvalImpulsesCache(state).gamma;
+  const auto& Adv = EvalMomentumCache(state).momentum_change;
+  cache.ellA = 0.5 * Adv.dot(v - v_star);
+  cache.ellR = 0.5 * gamma.dot(R.asDiagonal() * gamma);
+  cache.ell = cache.ellA + cache.ellR;
+  cache.valid = true;
+  return cache;
+}
+
+template <typename T>
+const typename SapSolver<T>::Cache::GradientsCache&
+SapSolver<T>::EvalGradientsCache(const State& state) const {
+  if (state.cache().gradients_cache().valid)
+    return state.cache().gradients_cache();
+  typename Cache::GradientsCache& cache =
+      state.mutable_cache().mutable_gradients_cache();
+
+  // Update ∇ᵥℓ = A⋅(v−v*) - Jᵀ⋅γ
+  const auto& momentum_cache = EvalMomentumCache(state);
+  const VectorX<T>& Adv = momentum_cache.momentum_change;  // = A⋅(v−v*)
+  const VectorX<T>& jc = momentum_cache.jc;  // = Jᵀ⋅γ
+  cache.ell_grad_v = Adv - jc;
+
+  // Update dPdy and G. G = -∂γ/∂vc = dP/dy⋅R⁻¹.
+  const VectorX<T>& y = EvalImpulsesCache(state).y;
+  CalcAllProjectionsGradients(y, &cache.dPdy);
+
+  const int nc = data_.nc;
+  const auto& R = data_.R;
+  const auto& dPdy = cache.dPdy;
+  for (int ic = 0; ic < nc; ++ic) {
+    const int ic3 = 3 * ic;
+    const auto& R_ic = R.template segment<3>(ic3);
+    const Vector3<T> Rinv_ic = R_ic.cwiseInverse();
+    const Matrix3<T>& dPdy_ic = dPdy[ic];
+    MatrixX<T>& G_ic = cache.G[ic];
+    G_ic = dPdy_ic * Rinv_ic.asDiagonal();
+  }
+
+  ++stats_.num_gradients_cache_updates;
+  cache.valid = true;
+  return cache;
+}
+
+template <typename T>
+const typename SapSolver<T>::Cache::SearchDirectionCache&
+SapSolver<T>::EvalSearchDirectionCache(const State& state) const {
+  if (state.cache().search_direction_cache().valid)
+    return state.cache().search_direction_cache();
+  typename Cache::SearchDirectionCache& cache =
+      state.mutable_cache().mutable_search_direction_cache();
+
+  // Update search direction dv.
+  CallDenseSolver(state, &cache.dv);
+
+  // Update Δp, Δvc and d²ellA/dα².
+  data_.J.Multiply(cache.dv, &cache.dvc);
+  data_.A.Multiply(cache.dv, &cache.dp);
+  cache.d2ellA_dalpha2 = cache.dv.dot(cache.dp);
+
+  cache.valid = true;
+  return cache;
 }
 
 }  // namespace internal

--- a/multibody/contact_solvers/sap_solver.h
+++ b/multibody/contact_solvers/sap_solver.h
@@ -21,8 +21,8 @@ struct SapSolverParameters {
   // where each component has the same units, square root of Joules. Therefore
   // the norms above are used to weigh all components of the generalized
   // momentum equally.
-  double abs_tolerance{1.0e-6};  // Absolute tolerance εₐ, square root of Joule.
-  double rel_tolerance{1.0e-6};  // Relative tolerance εᵣ.
+  double abs_tolerance{1.e-14};  // Absolute tolerance εₐ, square root of Joule.
+  double rel_tolerance{1.e-6};   // Relative tolerance εᵣ.
   int max_iterations{100};       // Maximum number of Newton iterations.
 
   // Line-search parameters.
@@ -76,12 +76,36 @@ class SapSolver final : public ContactSolver<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SapSolver);
 
+  // Struct used to store statistics for each solve by SolveWithGuess().
+  struct SolverStats {
+    // Initializes counters and time statistics to zero.
+    void Reset() {
+      num_iters = 0;
+      num_line_search_iters = 0;
+      num_impulses_cache_updates = 0;
+      num_gradients_cache_updates = 0;
+    }
+    int num_iters{0};              // Number of Newton iterations.
+    int num_line_search_iters{0};  // Total number of line search iterations.
+
+    // Number of impulse updates. This also includes dP/dy updates, when
+    // gradients are updated.
+    int num_impulses_cache_updates{0};
+
+    // Number of times the gradients cache is updated.
+    int num_gradients_cache_updates{0};
+  };
+
   SapSolver() = default;
   ~SapSolver() final = default;
 
   // Solve the contact problem specified by the input data. See
   // ContactSolver::SolveWithGuess() for details. Currently, only `T = double`
   // is supported. An exception is thrown if `T != double`.
+  //
+  // @pre dynamics_data must contain data for inverse dynamics, i.e.
+  // dynamics_data.has_inverse_dynamics() is true.
+  // @pre contact_data Must contain a non-zero number of contact constraints.
   ContactSolverStatus SolveWithGuess(const T& time_step,
                                      const SystemDynamicsData<T>& dynamics_data,
                                      const PointContactData<T>& contact_data,
@@ -93,8 +117,250 @@ class SapSolver final : public ContactSolver<T> {
     parameters_ = parameters;
   }
 
+  // Returns solver statistics from the last call to SolveWithGuess().
+  // Statistics are reset with SolverStats::Reset() on each new call to
+  // SolveWithGuess().
+  const SolverStats& get_statistics() const {
+    return stats_;
+  }
+
  private:
   friend class SapSolverTester;
+
+  // This class is used to store quantities that are a function of the
+  // generalized velocities in the State of the solver. This class does not
+  // provide a generic caching mechanism, but the dependencies are harcoded into
+  // the implementation. These dependencies are sketched below:
+  //
+  //      ┌───┐   ┌──┐   ┌────────┐   ┌───┐   ┌────┐   ┌────────────────┐
+  //      │ v │◄──┤vc│◄──┤Impulses│◄──┤Mom│◄──┤Grad│◄──┤Search Direction│
+  //      └───┘   └──┘   └────────┘   └───┘   └────┘   └────────────────┘
+  //                          ▲
+  //                          │    ┌────┐
+  //                          └────┤Cost│
+  //                               └────┘
+  // Entries in the schematic correspond to cache entries with type:
+  //  - vc: VelocitiesCache
+  //  - Impulses: ImpulsesCache
+  //  - Mom: MomentumCache
+  //  - Grad: GradientsCache
+  //  - Search Direction: SearchDirectionCache
+  //
+  // The SapSolver class provides methods to "evaluate" these cache entries and
+  // always return an up-to-date reference (the computation is performed only if
+  // the cache entry is not up-to-date.) As an example, consider the evaluation
+  // of the constraints velocity vc. This is accomplished with:
+  //   const VectorX<T>& vc = EvalVelocitiesCache(state).vc;
+  // Notice that the call site does not mention the cache directly but it uses
+  // the corresponding Eval method.
+  // Cache entries are invalidated as generalized velocities stored in the state
+  // are mutated with state.mutable_v().
+  //
+  // N.B. The schematic above must be kept in sync with the implementation.
+  //
+  // For mathematical quantities, we attempt follow the notation introduced in
+  // [Castro et al., 2021] as best as we can, though with ASCII and Unicode
+  // characters.
+  class Cache {
+   public:
+    DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Cache);
+    Cache() = default;
+
+    struct VelocitiesCache {
+      void Resize(int nc) { vc.resize(3 * nc); }
+      bool valid{false};
+      VectorX<T> vc;  // constraint velocities vc = J⋅v.
+    };
+
+    struct ImpulsesCache {
+      void Resize(int nc) {
+        y.resize(3 * nc);
+        gamma.resize(3 * nc);
+      }
+      bool valid{false};
+      VectorX<T> y;      // The (unprojected) impulse y = −R⁻¹⋅(vc − v̂).
+      VectorX<T> gamma;  // Impulse γ = P(y), with P(y) the projection operator.
+    };
+
+    struct MomentumCache {
+      void Resize(int nv) {
+        p.resize(nv);
+        jc.resize(nv);
+        momentum_change.resize(nv);
+      }
+      bool valid{false};
+      VectorX<T> p;                // Generalized momentum p = A⋅v
+      VectorX<T> jc;               // Generalized impulse jc = Jᵀ⋅γ
+      VectorX<T> momentum_change;  // = A⋅(v−v*)
+    };
+
+    struct CostCache {
+      bool valid{false};
+      T ell{0.0};   // Total primal cost, = ellA + ellR.
+      T ellA{0.0};  // Velocities cost, = 1/2⋅(v−v*)ᵀ⋅A⋅(v−v*).
+      T ellR{0.0};  // Regularizer cost, = 1/2⋅γᵀ⋅R⋅γ.
+    };
+
+    struct GradientsCache {
+      void Resize(int nv, int nc) {
+        ell_grad_v.resize(nv);
+        dPdy.resize(nc);
+        G.resize(nc, Matrix3<T>::Zero());
+      }
+      bool valid{false};
+      VectorX<T> ell_grad_v;         // Gradient of the cost in v.
+      std::vector<Matrix3<T>> dPdy;  // Gradient of the projection, ∂P/∂y.
+      std::vector<MatrixX<T>> G;     // G = -∂γ/∂vc = dP/dy⋅R⁻¹.
+    };
+
+    struct SearchDirectionCache {
+      void Resize(int nv, int nc) {
+        dv.resize(nv);
+        dp.resize(nv);
+        dvc.resize(3 * nc);
+      }
+      bool valid{false};
+      VectorX<T> dv;          // Search direction.
+      VectorX<T> dp;          // Momentum update Δp = A⋅Δv.
+      VectorX<T> dvc;         // Constraints velocities update, Δvc=J⋅Δv.
+      T d2ellA_dalpha2{NAN};  // d²ellA/dα² = Δvᵀ⋅A⋅Δv.
+    };
+
+    // Resizes all the cache entries to store quantities for a problem with nv
+    // generalized velocities and nc contact constraints.
+    void Resize(int nv, int nc);
+
+    // Marks the cache as invalid. This is meant to be called by State when
+    // mutating its internal state.
+    void mark_invalid() {
+      velocities_cache_.valid = false;
+      impulses_cache_.valid = false;
+      momentum_cache_.valid = false;
+      cost_cache_.valid = false;
+      gradients_cache_.valid = false;
+      search_direction_cache_.valid = false;
+    }
+
+    // Methods for const access of cache entries. These methods are meant to be
+    // used only within Eval methods. Cache entries must be accessed through the
+    // corresponding Eval.
+    // TODO(amcastro-tri): Per review of #16080, remove these const access
+    // methods so that there is no possibility of a developer accessing an
+    // out-of-date cache entry. Consider a design where pre-processed data and
+    // calc methods are part of a SapModel class (to replace PreProcessedData).
+    // Then State would be the only object that knows how to access (valid)
+    // cache entries. Like so:
+    //   SapModel<T> model;
+    //   ... Model initialized at pre-process time.
+    //   State state(...)
+    //   const VectorX<T>& vc = state.EvalVelocitiesCache(model).vc;
+    const VelocitiesCache& velocities_cache() const {
+      return velocities_cache_;
+    }
+    const ImpulsesCache& impulses_cache() const { return impulses_cache_; }
+    const MomentumCache& momentum_cache() const { return momentum_cache_; }
+    const CostCache& cost_cache() const { return cost_cache_; }
+    const GradientsCache& gradients_cache() const { return gradients_cache_; }
+    const SearchDirectionCache& search_direction_cache() const {
+      return search_direction_cache_;
+    }
+
+    // Methods for mutable access of cache entries. The specific cache entry and
+    // its dependents are marked invalid before it is returned. These methods
+    // are meant to be used only within Eval methods. Cache entries must be
+    // accessed through the corresponding Eval.
+    VelocitiesCache& mutable_velocities_cache() {
+      velocities_cache_.valid = false;
+      impulses_cache_.valid = false;
+      momentum_cache_.valid = false;
+      cost_cache_.valid = false;
+      gradients_cache_.valid = false;
+      search_direction_cache_.valid = false;
+      return velocities_cache_;
+    }
+    ImpulsesCache& mutable_impulses_cache() {
+      impulses_cache_.valid = false;
+      momentum_cache_.valid = false;
+      cost_cache_.valid = false;
+      gradients_cache_.valid = false;
+      search_direction_cache_.valid = false;
+      return impulses_cache_;
+    }
+    MomentumCache& mutable_momentum_cache() {
+      momentum_cache_.valid = false;
+      gradients_cache_.valid = false;
+      search_direction_cache_.valid = false;
+      return momentum_cache_;
+    }
+    CostCache& mutable_cost_cache() {
+      cost_cache_.valid = false;
+      return cost_cache_;
+    }
+    GradientsCache& mutable_gradients_cache() {
+      gradients_cache_.valid = false;
+      search_direction_cache_.valid = false;
+      return gradients_cache_;
+    }
+    SearchDirectionCache& mutable_search_direction_cache() {
+      search_direction_cache_.valid = false;
+      return search_direction_cache_;
+    }
+
+   private:
+    VelocitiesCache velocities_cache_;
+    MomentumCache momentum_cache_;
+    ImpulsesCache impulses_cache_;
+    GradientsCache gradients_cache_;
+    CostCache cost_cache_;
+    SearchDirectionCache search_direction_cache_;
+  };
+
+  // Everything in this solver is a function of the generalized velocities v;
+  // cost ℓ(v), gradient ∇ℓ(v), Hessian H(v), intermediate quantities used for
+  // their computation and even search direction Δv(v) and Hessian
+  // factorization. State stores generalized velocities v and cached quantities
+  // that are functions of v. The purpose of cached quantities is twofold; 1) to
+  // allow reusing already computed quantities and 2) to centralize and
+  // minimize (costly) heap allocations.
+  class State {
+   public:
+    DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(State);
+
+    State() = default;
+
+    // Constructs a state for a problem with nv generalized velocities and nc
+    // contact constraints.
+    State(int nv, int nc) { Resize(nv, nc); }
+
+    // Resizes the state for a problem with nv generalized velocities and nc
+    // contact constraints.
+    void Resize(int nv, int nc) {
+      v_.resize(nv);
+      cache_.Resize(nv, nc);
+    }
+
+    const VectorX<T>& v() const { return v_; }
+
+    VectorX<T>& mutable_v() {
+      // Mark all cache quantities as invalid since they all are a function of
+      // velocity.
+      cache_.mark_invalid();
+      return v_;
+    }
+
+    const Cache& cache() const { return cache_; }
+
+    // The state of the solver is fully described by the generalized velocities
+    // v. Therefore mutating the cache does not change the state of the solver
+    // and we mark this method "const". Mutable access to the cache is provided
+    // to allow updating expensive quantities that are reused in multiple
+    // places.
+    Cache& mutable_cache() const { return cache_; }
+
+   private:
+    VectorX<T> v_;
+    mutable Cache cache_;
+  };
 
   // Structure used to store input data pre-processed for computation. For
   // mathematical quantities, we attempt to follow the notation introduced in
@@ -139,7 +405,7 @@ class SapSolver final : public ContactSolver<T> {
     VectorX<T> mu;           // Friction coefficients, of size nc.
     BlockSparseMatrix<T> J;  // Jacobian as block-sparse matrix.
     BlockSparseMatrix<T> A;  // Momentum matrix as block-sparse matrix.
-    std::vector<MatrixX<T>> At;   // Per-tree blocks of the momentum matrix.
+    std::vector<MatrixX<T>> At;  // Per-tree blocks of the momentum matrix.
 
     // Inverse of the diagonal matrix formed with the square root of the
     // diagonal entries of the momentum matrix, i.e. inv_sqrt_A =
@@ -172,6 +438,29 @@ class SapSolver final : public ContactSolver<T> {
       const T& time_step, const SystemDynamicsData<T>& dynamics_data,
       const PointContactData<T>& contact_data) const;
 
+  // Computes gamma = P(y) where P(y) is the projection of y onto the friction
+  // cone defined by `mu` using the norm defined by `R`. The gradient dP/dy of
+  // the operator is computed if dPdy != nullptr.
+  // See [Castro et al., 2021] for details on the projection operator (Section
+  // VII) and its gradients (Appendix E).
+  //
+  // @pre R has the form R = (Rt, Rt, Rn).
+  Vector3<T> ProjectSingleImpulse(
+      const T& mu, const Eigen::Ref<const Vector3<T>>& R,
+      const Eigen::Ref<const Vector3<T>>& y, Matrix3<T>* dPdy = nullptr) const;
+
+  // Computes the projection gamma = P(y) for all impulses.
+  // @pre gamma must already be properly sized.
+  void ProjectAllImpulses(const VectorX<T>& y, VectorX<T>* gamma) const;
+
+  // Computes the gradient dP/dy of the projection gamma = P(y) computed by
+  // ProjectAllImpulses().
+  // @pre dPdy must already be properly sized.
+  // TODO(amcastro-tri): consider caching common terms computed by
+  // ProjectAllImpulses() so that they can be re-used by this method.
+  void CalcAllProjectionsGradients(const VectorX<T>& y,
+                                   std::vector<Matrix3<T>>* dPdy) const;
+
   // Pack solution into ContactSolverResults. Where v is the vector of
   // generalized velocities, vc is the vector of contact velocities and gamma is
   // the vector of generalized contact impulses.
@@ -180,10 +469,76 @@ class SapSolver final : public ContactSolver<T> {
                                  const VectorX<T>& gamma,
                                  ContactSolverResults<T>* result);
 
-  const SapSolverParameters& parameters() const { return parameters_; }
+  // We monitor the optimality condition (for SAP, balance of momentum), i.e.
+  // ‖∇ℓ‖ < εₐ + εᵣ max(‖p‖,‖j‖), where ∇ℓ = A⋅(v−v*)−Jᵀγ is the momentum
+  // balance residual, p = A⋅v and j = Jᵀ⋅γ. The norms above are weighted as ‖x‖
+  // = ‖D⋅x‖₂ where D = diag(A)^(1/2), such that all generalized momenta have
+  // the same units (squared root of Joules).
+  // This method computes momentum_residual = ‖∇ℓ‖ and momentum_scale =
+  // max(‖p‖,‖j‖). See [Castro et al., 2021] for further details.
+  void CalcStoppingCriteriaResidual(const State& state, T* momentum_residual,
+                                    T* momentum_scale) const;
 
+  // Solves the contact problem from initial guess `v_guess` into `result`.
+  // @pre PreProcessData() has already been called.
+  ContactSolverStatus DoSolveWithGuess(const VectorX<T>& v_guess,
+                                       ContactSolverResults<T>* result);
+
+  // Computes the cost ℓ(α) = ℓ(vᵐ + αΔvᵐ) for line search, where vᵐ and Δvᵐ are
+  // the last Newton iteration values of generalized velocities and search
+  // direction, respectively. This methods uses the O(n) strategy described in
+  // [Castro et al., 2021].
+  T CalcLineSearchCost(const State& state_v, const T& alpha,
+                       State* state_alpha) const;
+
+  // Approximation to the 1D minimization problem α = argmin ℓ(α) = ℓ(v + αΔv)
+  // over α. We define ϕ(α) = ℓ₀ + α c ℓ₀', where ℓ₀ = ℓ(0), ℓ₀' = dℓ/dα(0) and
+  // c is the Armijo's criterion parameter. With this definition the Armijo
+  // condition reads ℓ(α) < ϕ(α). This approximate method seeks to minimize ℓ(α)
+  // over a discrete set of values given by the geometric progression αᵣ =
+  // ρʳαₘₐₓ with r an integer, 0 < ρ < 1 and αₘₐₓ the maximum value of α
+  // allowed. That is, the exact problem is replaced by a search over the
+  // discrete values αᵣ until Armijo's criteria is satisfied. The satisfaction
+  // of Armijo's criteria allows to prove the global convergence of SAP.
+  // For a good reference on this method, see Section 11.3 of Bierlaire, M.,
+  // 2015. "Optimization: principles and algorithms", EPFL Press.
+  //
+  // @returns A value of α that satisfies Armijo's criterion.
+  T PerformBackTrackingLineSearch(const State& state, const VectorX<T>& dv,
+                                  int* num_iterations) const;
+
+  // Solves for dv using dense algebra, for debugging.
+  // TODO(amcastro-tri): Add AutoDiffXd support.
+  void CallDenseSolver(const State& s, VectorX<T>* dv) const;
+
+  // Methods used to evaluate cached quantities.
+  const typename Cache::VelocitiesCache& EvalVelocitiesCache(
+      const State& state) const;
+  const typename Cache::ImpulsesCache& EvalImpulsesCache(
+      const State& state) const;
+  const typename Cache::CostCache& EvalCostCache(const State& state) const;
+  const typename Cache::MomentumCache& EvalMomentumCache(
+      const State& state) const;
+  const typename Cache::GradientsCache& EvalGradientsCache(
+      const State& state) const;
+  const typename Cache::SearchDirectionCache& EvalSearchDirectionCache(
+      const State& state) const;
+
+  // Quick access to mutable non thread-safe data.
+  const PreProcessedData& data() const { return data_; }
+
+  // All data stored by this class.
   SapSolverParameters parameters_;
+  PreProcessedData data_;
+  // Since SolveWithGuess() is non-const, there is no real reason to make this
+  // member mutable, only convenience to update it within (const) eval methods.
+  // TODO(amcastro-tri): Consider moving stats into the State.
+  mutable SolverStats stats_;
 };
+
+template <>
+ContactSolverStatus SapSolver<double>::DoSolveWithGuess(
+    const VectorX<double>&, ContactSolverResults<double>*);
 
 }  // namespace internal
 }  // namespace contact_solvers

--- a/multibody/contact_solvers/test/sap_solver_test.cc
+++ b/multibody/contact_solvers/test/sap_solver_test.cc
@@ -1,5 +1,13 @@
 #include "drake/multibody/contact_solvers/sap_solver.h"
 
+// TODO(amcastro-tri): While many of tests in this file verify the correctness
+// of the solution, it might not be enough to ensure the entire implementation
+// is correct. E.g. miscalculation of the Hessian could lead to slower
+// convergence. Consider more fine grained unit tests, especially for the
+// Hessian and other gradients.
+
+#include <memory>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
@@ -10,8 +18,10 @@
 #include "drake/multibody/contact_solvers/system_dynamics_data.h"
 
 using Eigen::Matrix3d;
-using Eigen::Vector3d;
 using Eigen::MatrixXd;
+using Eigen::Vector2d;
+using Eigen::Vector3d;
+using Eigen::Vector4d;
 using Eigen::VectorXd;
 
 namespace drake {
@@ -116,18 +126,18 @@ struct ProblemData {
 // data in SAP.
 class ParticlesStackProblem {
  public:
-  static constexpr int num_particles = 3;   // Number of particles.
-  static constexpr int num_velocities = 9;  // Three particles in 3D.
-  static constexpr int num_contacts = 3;    // Vertical stack.
+  static constexpr int kNumParticles = 3;   // Number of particles.
+  static constexpr int kNumVelocities = 9;  // Three particles in 3D.
+  static constexpr int kNumContacts = 3;    // Vertical stack.
 
   // Arbitrary non-zero free-motion velocities.
   VectorXd MakeFreeMotionVelocities() const {
-    return VectorXd::LinSpaced(num_velocities, 0, num_velocities);
+    return VectorXd::LinSpaced(kNumVelocities, 0, kNumVelocities);
   }
 
   // Arbitrary particle masses.
   VectorXd GetParticleMasses() const {
-    return 1.5 * VectorXd::LinSpaced(num_particles, 1, num_particles);
+    return 1.5 * VectorXd::LinSpaced(kNumParticles, 1, kNumParticles);
   }
 
   // Mass matrix for the system of three particles.
@@ -135,7 +145,7 @@ class ParticlesStackProblem {
     const VectorXd masses = GetParticleMasses();
     BlockSparseMatrixBuilder<double> builder(3, 3, 3);
     // Each particle is a block.
-    for (int p = 0; p < num_particles; ++p) {
+    for (int p = 0; p < kNumParticles; ++p) {
       builder.PushBlock(p, p, masses[p] * Matrix3d::Identity());
     }
     *M = builder.Build();
@@ -145,7 +155,7 @@ class ParticlesStackProblem {
   // a stack. Particle 2 on the ground, particle 1 on 2 and particle 0 on 1.
   void MakeContactJacobian(BlockSparseMatrix<double>* J) const {
     const MatrixXd Jblock = MatrixXd::Identity(3, 3);
-    BlockSparseMatrixBuilder<double> builder(num_contacts, num_particles, 5);
+    BlockSparseMatrixBuilder<double> builder(kNumContacts, kNumParticles, 5);
     // Contact between particles 0 and 1.
     builder.PushBlock(0, 0, Jblock);
     builder.PushBlock(0, 1, Jblock);
@@ -159,7 +169,7 @@ class ParticlesStackProblem {
 
   std::unique_ptr<ProblemData> MakeProblemData() const {
     // Set system dynamics data:
-    auto data = std::make_unique<ProblemData>(num_velocities, num_contacts);
+    auto data = std::make_unique<ProblemData>(kNumVelocities, kNumContacts);
     data->time_step = 5.0e-3;
     CalcMassMatrix(&data->Ablock);
     data->M = data->Ablock.MakeDenseMatrix();
@@ -176,10 +186,10 @@ class ParticlesStackProblem {
     data->Jop =
         std::make_unique<BlockSparseLinearOperator<double>>("J", &data->Jblock);
 
-    data->phi0.setLinSpaced(num_contacts, 1., num_contacts);
-    data->stiffness.setLinSpaced(num_contacts, 1., num_contacts);
-    data->dissipation.setLinSpaced(num_contacts, 1., num_contacts);
-    data->mu.setLinSpaced(num_contacts, 1., num_contacts);
+    data->phi0.setLinSpaced(kNumContacts, 1., kNumContacts);
+    data->stiffness.setLinSpaced(kNumContacts, 1., kNumContacts);
+    data->dissipation.setLinSpaced(kNumContacts, 1., kNumContacts);
+    data->mu.setLinSpaced(kNumContacts, 1., kNumContacts);
 
     data->contact_data = std::make_unique<PointContactData<double>>(
         &data->phi0, data->Jop.get(), &data->stiffness, &data->dissipation,
@@ -200,8 +210,8 @@ GTEST_TEST(SapSolver, PreProcessedData) {
       *problem_data->contact_data);
 
   EXPECT_EQ(data.time_step, problem_data->time_step);
-  EXPECT_EQ(data.nv, problem.num_velocities);
-  EXPECT_EQ(data.nc, problem.num_contacts);
+  EXPECT_EQ(data.nv, problem.kNumVelocities);
+  EXPECT_EQ(data.nc, problem.kNumContacts);
   EXPECT_EQ(data.mu, problem_data->mu);
   EXPECT_EQ(data.J.MakeDenseMatrix(), problem_data->J);
   EXPECT_EQ(data.A.MakeDenseMatrix(), problem_data->M);
@@ -230,23 +240,465 @@ GTEST_TEST(SapSolver, PreProcessedData) {
   EXPECT_TRUE(CompareMatrices(data.delassus_diagonal, Wdiag_expected,
                               std::numeric_limits<double>::epsilon(),
                               MatrixCompareType::relative));
-
-  // Verify regularization parameters.
-  const VectorXd& k = problem_data->stiffness.array();
-  const VectorXd& c = problem_data->dissipation.array();
+  const VectorXd& k = problem_data->stiffness;
+  const VectorXd& c = problem_data->dissipation;
   const double dt = problem_data->time_step;
   const VectorXd taud = c.array() / k.array();
   const VectorXd Rn_expected =
       ((dt + taud.array()) * k.array() * dt).cwiseInverse();
   const VectorXd Rt_expected = parameters.sigma * Wdiag_expected;
-  VectorXd R_expected(3 * problem.num_contacts);
-  for (int i = 0; i < problem.num_contacts; ++i) {
+  VectorXd R_expected(3 * problem.kNumContacts);
+  for (int i = 0; i < problem.kNumContacts; ++i) {
     R_expected.segment<3>(3 * i) =
         Vector3d(Rt_expected(i), Rt_expected(i), Rn_expected(i));
   }
   EXPECT_TRUE(CompareMatrices(data.R, R_expected,
                               std::numeric_limits<double>::epsilon(),
                               MatrixCompareType::relative));
+}
+
+/* Model of a "pizza saver":
+
+  ^ y
+  |                 ◯ C
+  |                /\
+  ----> x         /  \
+               a /    \ a
+                /      \
+               /        \
+            A ◯----------◯ B
+                   a
+
+It is modeled as an equilateral triangle with a contact point at each of the
+vertices. The total mass of the pizza saver is m and its rotational inertia
+about the triangle's barycenter is I. If h is the height of the triangle from
+any of its sides, the distance from any point to the triangle's center is 2h/3.
+The height h relates to the length a of a side by h = sqrt(3)/2 a. The
+generalized positions vector for this case is q = [x, y, z, theta], with theta =
+0 for the triangle in the configuration shown in the schematic. */
+class PizzaSaverProblem {
+ public:
+  static constexpr int kNumVelocities = 4;
+  static constexpr int kNumContacts = 3;
+
+  // @param dt Discrete time step.
+  // @param mass Total mass of the system, in Kg.
+  // @param radius Radius of the circle circumscribing the triangular pizza
+  // saver, in m.
+  // @param mu Coefficient of dynamic friction.
+  // @param k Stiffness with the ground, in N/m.
+  // @param taud Dissipation time scale, in seconds.
+  PizzaSaverProblem(double dt, double mass, double radius, double mu, double k,
+                    double taud)
+      : time_step_(dt),
+        m_(mass),
+        radius_(radius),
+        mu_(mu),
+        stiffness_(k),
+        taud_(taud) {
+    // The radius of the circumscribed circle R is the distance from each
+    // contact point to the triangle's center.
+    // We model the pizza saver as three point masses m/3 at each contact
+    // point and thus the moment of inertia is I = 3 * (m/3 R²) = m R²:
+    I_ = m_ * radius_ * radius_;
+  }
+
+  // Pizza saver model with default mass m = 3 Kg and radius = 1.5 m.
+  PizzaSaverProblem(double dt, double mu, double k, double taud)
+      : PizzaSaverProblem(dt, 3.0, 1.5, mu, k, taud) {}
+
+  double time_step() const { return time_step_; }
+
+  // Mass of each point mass, Kg. Total mass is three times mass().
+  double mass() const { return m_; }
+
+  double radius() const { return radius_; }
+
+  double rotational_inertia() const { return I_; }
+
+  // Acceleration of gravity, m/s².
+  double g() const { return g_; }
+
+  void CalcMassMatrix(MatrixXd* M) const {
+    M->resize(kNumVelocities, kNumVelocities);
+    // clang-format off
+    *M << m_,  0,  0,  0,
+           0, m_,  0,  0,
+           0,  0, m_,  0,
+           0,  0,  0, I_;
+    // clang-format on
+  }
+
+  void CalcContactJacobian(double theta, MatrixXd* Jc) const {
+    Jc->resize(3 * kNumContacts, kNumVelocities);
+
+    const double c = std::cos(theta);
+    const double s = std::sin(theta);
+
+    // 3D rotation matrix of the body frame B in the world frame W.
+    // clang-format off
+    Matrix3d R_WB;
+    R_WB << c, s, 0,
+           -s, c, 0,
+            0, 0, 1;
+    // clang-format on
+
+    // Position of each contact point in the body frame B.
+    const Vector3d p_BoA = radius_ * Vector3d(-sqrt(3) / 2.0, -0.5, 0.0);
+    const Vector3d p_BoB = radius_ * Vector3d(sqrt(3) / 2.0, -0.5, 0.0);
+    const Vector3d p_BoC = radius_ * Vector3d(0.0, 1.0, 0.0);
+
+    // Position of each contact point in the world frame W.
+    const Vector3d p_BoA_W = R_WB * p_BoA;
+    const Vector3d p_BoB_W = R_WB * p_BoB;
+    const Vector3d p_BoC_W = R_WB * p_BoC;
+
+    // clang-format off
+    // Point A
+    Jc->middleRows<3>(0) << 1, 0, 0, -p_BoA_W.y(),
+                            0, 1, 0,  p_BoA_W.x(),
+                            0, 0, 1, 0;
+
+    // Point B
+    Jc->middleRows<3>(3) << 1, 0, 0, -p_BoB_W.y(),
+                            0, 1, 0, p_BoB_W.x(),
+                            0, 0, 1, 0;
+
+    // Point C
+    Jc->middleRows<3>(6) << 1, 0, 0, -p_BoC_W.y(),
+                            0, 1, 0, p_BoC_W.x(),
+                            0, 0, 1, 0;
+    // clang-format on
+  }
+
+  // Makes the problem data to advance the dynamics of the pizza saver from
+  // state x0 = [q0, v0], with applied forces tau = (fx, fy, fz, Mz).
+  std::unique_ptr<ProblemData> MakeProblemData(const VectorXd& q0,
+                                               const VectorXd& v0,
+                                               const VectorXd& tau) const {
+    // Set system dynamics data:
+    auto data = std::make_unique<ProblemData>(kNumVelocities, kNumContacts);
+    CalcMassMatrix(&data->M);
+    {
+      // A single block size.
+      BlockSparseMatrixBuilder<double> builder(1, 1, 1);
+      builder.PushBlock(0, 0, data->M);
+      data->Ablock = builder.Build();
+    }
+    data->Mop =
+        std::make_unique<BlockSparseLinearOperator<double>>("M", &data->Ablock);
+
+    data->v_star.resize(kNumVelocities);
+    data->v_star = v0 + time_step_ * data->M.ldlt().solve(tau);
+
+    data->dynamics_data = std::make_unique<SystemDynamicsData<double>>(
+        data->Mop.get(), nullptr, &data->v_star);
+
+    // Set contact data:
+    CalcContactJacobian(q0(3), &data->J);
+    {
+      // A single block size.
+      BlockSparseMatrixBuilder<double> builder(1, 1, 1);
+      builder.PushBlock(0, 0, data->J);
+      data->Jblock = builder.Build();
+    }
+    data->Jop =
+        std::make_unique<BlockSparseLinearOperator<double>>("J", &data->Jblock);
+
+    data->phi0.setConstant(kNumContacts, q0(2));
+    data->stiffness.setConstant(kNumContacts, stiffness_);
+    data->dissipation.setConstant(kNumContacts, taud_ * stiffness_);
+    data->mu.setConstant(kNumContacts, mu_);
+
+    data->contact_data = std::make_unique<PointContactData<double>>(
+        &data->phi0, data->Jop.get(), &data->stiffness, &data->dissipation,
+        &data->mu);
+
+    return data;
+  }
+
+ private:
+  // Helper method for NaN initialization.
+  static constexpr double nan() {
+    return std::numeric_limits<double>::quiet_NaN();
+  }
+
+  // The physical parameters of the model. They are initialized with NaN for a
+  // quick detection of uninitialized values.
+  double time_step_{nan()};  // Discrete time step.
+
+  // Pizza saver parameters.
+  double m_{nan()};  // Mass of the pizza saver.
+  double radius_{nan()};  // Distance from COM to any contact point.
+  double I_{nan()};  // Rotational inertia about the z axis.
+
+  // Contact parameters:
+  double mu_{nan()};         // Friction coefficient.
+  double stiffness_{nan()};  // Contact stiffness k.
+  double taud_{nan()};       // Linear dissipation time scale: c = taud * k.
+
+  const double g_{10.0};  // Acceleration of gravity.
+};
+
+ContactSolverResults<double> AdvanceNumSteps(
+    const PizzaSaverProblem& problem, const VectorXd& tau, int num_steps,
+    const SapSolverParameters& params) {
+  SapSolver<double> sap;
+  sap.set_parameters(params);
+  ContactSolverResults<double> result;
+  // Arbitrary non-zero guess to stress the solver.
+  VectorXd v_guess(problem.kNumVelocities);
+  v_guess << 1.0, 2.0, 3.0, 4.0;
+
+  const double theta = M_PI / 5;  // Arbitrary orientation.
+  VectorXd q = Vector4d(0.0, 0.0, 0.0, theta);
+  VectorXd v = VectorXd::Zero(problem.kNumVelocities);
+
+  for (int i = 0; i < num_steps; ++i) {
+    const auto data = problem.MakeProblemData(q, v, tau);
+    const ContactSolverStatus status =
+        sap.SolveWithGuess(problem.time_step(), *data->dynamics_data,
+                           *data->contact_data, v_guess, &result);
+    EXPECT_EQ(status, ContactSolverStatus::kSuccess);
+    v = result.v_next;
+    q += problem.time_step() * v;
+
+    // Verify the number of times cache entries were updated.
+    const SapSolver<double>::SolverStats& stats = sap.get_statistics();
+
+    // N.B. We only count iterations that perform factorizations. Since impulses
+    // need to be computed in order to evaluate the termination criteria (before
+    // a factorization might be carried out), the expected number of gradients
+    // update equals the number of iterations plus one.
+    EXPECT_EQ(stats.num_gradients_cache_updates, stats.num_iters + 1);
+
+    // Impulses are evaluated:
+    //  - At the very beginning of an iteration, to evaluate stopping criteria
+    //    (num_iters+1 since the last iteration does not perform factorization.)
+    //  - At the very beginning of line search iterations, i.e. num_iters.
+    //  - Once per line search iteration.
+    //    Therefore we expect impulses to be evaluated
+    //    num_line_search_iters+2*num_iters+1 times.
+    EXPECT_EQ(stats.num_impulses_cache_updates,
+              stats.num_line_search_iters + 2 * stats.num_iters + 1);
+  }
+
+  return result;
+}
+
+// Solve a problem with no applied torque. In this case contact forces should
+// balance weight.
+GTEST_TEST(PizzaSaver, NoAppliedTorque) {
+  const double dt = 0.01;
+  const double mu = 1.0;
+  const double k = 1.0e4;
+  const double taud = dt;
+  const PizzaSaverProblem problem(dt, mu, k, taud);
+
+  SapSolverParameters params;
+  params.rel_tolerance = 1.0e-6;
+  params.beta = 0;  // No near-rigid regime.
+  params.ls_max_iterations = 40;
+
+  const Vector4d tau(0.0, 0.0, -problem.mass() * problem.g(), 0.0);
+  const ContactSolverResults<double> result =
+      AdvanceNumSteps(problem, tau, 30, params);
+
+  // N.B. The accuracy of the solutions is significantly higher when using exact
+  // line search.
+  // TODO(amcastro-tri): Tighten tolerances for runs with exact line search.
+
+  // Expected generalized force.
+  Vector4d tau_expected(0.0, 0.0, problem.mass() * problem.g(), 0.0);
+
+  EXPECT_TRUE(CompareMatrices(result.v_next,
+                              VectorXd::Zero(problem.kNumVelocities),
+                              params.rel_tolerance));
+  EXPECT_TRUE((result.tau_contact - tau_expected).norm() / tau_expected.norm() <
+              params.rel_tolerance);
+  EXPECT_TRUE(CompareMatrices(result.ft,
+                              VectorXd::Zero(2 * problem.kNumContacts),
+                              2.0 * params.rel_tolerance));
+  EXPECT_TRUE(CompareMatrices(
+      result.fn,
+      VectorXd::Constant(problem.kNumContacts, tau_expected(2) / 3.0),
+      params.rel_tolerance, MatrixCompareType::relative));
+  EXPECT_TRUE(CompareMatrices(result.vt,
+                              VectorXd::Zero(2 * problem.kNumContacts),
+                              params.rel_tolerance));
+  EXPECT_TRUE(CompareMatrices(result.vn, VectorXd::Zero(problem.kNumContacts),
+                              params.rel_tolerance));
+}
+
+// We verify SAP returns immediately when the exact guess is provided. To stress
+// test this case, the maximum number of iterations is set to zero. We expect
+// SAP to return the guess as the solution.
+GTEST_TEST(PizzaSaver, ConvergenceWithExactGuess) {
+  const double dt = 0.01;
+  const double mu = 1.0;
+  const double k = 1.0e4;
+  const double taud = dt;
+  const PizzaSaverProblem problem(dt, mu, k, taud);
+
+  SapSolverParameters params;
+  params.rel_tolerance = 1.0e-6;
+  params.beta = 0;  // No near-rigid regime.
+  params.ls_max_iterations = 40;
+  params.max_iterations = 0;
+
+  const double weight = problem.mass() * problem.g();
+  const Vector4d tau(0.0, 0.0, -weight, 0.0);
+
+  // We set the initial position so that the (three) compliant point contact
+  // forces balance weight.
+  const double z = -weight / k / 3.0;
+  const double theta = M_PI / 5;  // Arbitrary orientation.
+  VectorXd q = Vector4d(0.0, 0.0, z, theta);
+  VectorXd v = VectorXd::Zero(problem.kNumVelocities);
+
+  const auto data = problem.MakeProblemData(q, v, tau);
+  SapSolver<double> sap;
+  sap.set_parameters(params);
+  ContactSolverResults<double> result;
+  const ContactSolverStatus status =
+      sap.SolveWithGuess(problem.time_step(), *data->dynamics_data,
+                         *data->contact_data, v, &result);
+  EXPECT_EQ(status, ContactSolverStatus::kSuccess);
+
+  // Verify no iterations were performed.
+  const SapSolver<double>::SolverStats& stats = sap.get_statistics();
+  EXPECT_EQ(stats.num_iters, 0);
+
+  // The guess was not even touched but directly copied into the results.
+  EXPECT_EQ(result.v_next, v);
+}
+
+// This tests the solver when we apply a moment Mz about COM to the pizza
+// saver. If Mz < mu * m * g * R, the saver should be in stiction (that is,
+// the sliding velocity should be smaller than the regularization parameter).
+// Otherwise the saver will start sliding. For this setup the transition
+// occurs at M_transition = mu * m * g * R = 30.
+GTEST_TEST(PizzaSaver, Stiction) {
+  const double dt = 0.01;
+  const double mu = 2. / 3.;
+  const double k = 1.0e4;
+  const double taud = dt;
+  PizzaSaverProblem problem(dt, mu, k, taud);
+
+  SapSolverParameters params;
+  params.rel_tolerance = 1.0e-6;
+  params.beta = 0;  // No near-rigid regime.
+  params.ls_max_iterations = 40;
+
+  const double Mz = 20.0;
+  const Vector4d tau(0.0, 0.0, -problem.mass() * problem.g(), Mz);
+  const ContactSolverResults<double> result =
+      AdvanceNumSteps(problem, tau, 30, params);
+
+  // Expected generalized force.
+  const Vector4d tau_expected(0.0, 0.0, problem.mass() * problem.g(), -Mz);
+
+  // Maximum expected slip. See Castro et al. 2021 for details (Eq. 22).
+  const double max_slip_expected = params.sigma * dt * problem.g();
+
+  EXPECT_TRUE(
+      CompareMatrices(result.v_next.head<3>(), Vector3d::Zero(), 1.0e-9));
+  EXPECT_TRUE((result.tau_contact - tau_expected).norm() / tau_expected.norm() <
+              params.rel_tolerance);
+  EXPECT_TRUE(CompareMatrices(
+      result.fn,
+      VectorXd::Constant(problem.kNumContacts, tau_expected(2) / 3.0),
+      params.rel_tolerance, MatrixCompareType::relative));
+  EXPECT_TRUE(CompareMatrices(result.vn, VectorXd::Zero(problem.kNumContacts),
+                              1.0e-9));
+  const double friction_force_expected = Mz / problem.radius() / 3.0;
+  for (int i = 0; i < 3; ++i) {
+    const double slip = result.vt.segment<2>(2 * i).norm();
+    const double friction_force = result.ft.segment<2>(2 * i).norm();
+    const double normal_force = result.fn(i);
+    EXPECT_LE(friction_force, mu * normal_force);
+    EXPECT_NEAR(friction_force, friction_force_expected,
+                params.rel_tolerance * friction_force_expected);
+    EXPECT_LE(slip, max_slip_expected);
+  }
+}
+
+// Test case with zero friction coefficient.
+GTEST_TEST(PizzaSaver, NoFriction) {
+  const double dt = 0.01;
+  const double mu = 0.0;
+  const double k = 1.0e4;
+  const double taud = dt;
+  const int num_steps = 30;
+  PizzaSaverProblem problem(dt, mu, k, taud);
+
+  SapSolverParameters params;
+  params.rel_tolerance = 1.0e-6;
+  params.beta = 0;  // No near-rigid regime.
+  params.ls_max_iterations = 40;
+
+  const double fx = 1.0;
+  const Vector4d tau(fx, 0.0, -problem.mass() * problem.g(), 0.0);
+  const ContactSolverResults<double> result =
+      AdvanceNumSteps(problem, tau, num_steps, params);
+
+  // Expected generalized force.
+  const Vector4d tau_expected(0.0, 0.0, problem.mass() * problem.g(), 0.0);
+
+  const double vx_expected = num_steps * dt * fx / problem.mass();
+
+  EXPECT_TRUE(CompareMatrices(result.v_next,
+                              Vector4d(vx_expected, 0.0, 0.0, 0.0),
+                              2.0 * params.rel_tolerance));
+  EXPECT_TRUE(CompareMatrices(result.tau_contact, tau_expected,
+                              2.0 * params.rel_tolerance,
+                              MatrixCompareType::relative));
+  EXPECT_TRUE(CompareMatrices(result.ft,
+                              VectorXd::Zero(2 * problem.kNumContacts),
+                              std::numeric_limits<double>::epsilon()));
+  EXPECT_TRUE(CompareMatrices(
+      result.fn,
+      VectorXd::Constant(problem.kNumContacts, tau_expected(2) / 3.0),
+      2.0 * params.rel_tolerance, MatrixCompareType::relative));
+  EXPECT_TRUE(CompareMatrices(result.vn, VectorXd::Zero(problem.kNumContacts),
+                              1.0e-13));
+  for (int i = 0; i < 3; ++i) {
+    const auto vt = result.vt.segment<2>(2 * i);
+    EXPECT_TRUE(CompareMatrices(vt, Vector2d(vx_expected, 0.0),
+                                2.0 * params.rel_tolerance,
+                                MatrixCompareType::relative));
+  }
+}
+
+// This tests the solver when we apply a moment Mz about COM to the pizza
+// saver. If Mz > mu * m * g * R, the saver will slide.
+// occurs at M_transition = mu * m * g * R = 30.0
+GTEST_TEST(PizzaSaver, Sliding) {
+  const double dt = 0.01;
+  const double mu = 2. / 3.;
+  const double k = 1.0e4;
+  const double taud = dt;
+  PizzaSaverProblem problem(dt, mu, k, taud);
+
+  SapSolverParameters params;
+  params.rel_tolerance = 1.0e-6;
+  params.beta = 0;  // No near-rigid regime.
+  params.ls_max_iterations = 40;
+
+  const double Mz = 40.0;
+  const double weight = problem.mass() * problem.g();
+  const Vector4d tau(0.0, 0.0, -weight, Mz);
+
+  const ContactSolverResults<double> result =
+      AdvanceNumSteps(problem, tau, 10, params);
+
+  EXPECT_GT(result.v_next(3), 0.0);  // It's accelerating.
+  for (int i = 0; i < 3; ++i) {
+    const double friction_force = result.ft.segment<2>(2 * i).norm();
+    const double normal_force = result.fn(i);
+    EXPECT_NEAR(friction_force, mu * normal_force,
+                std::numeric_limits<double>::epsilon() * normal_force);
+  }
 }
 
 }  // namespace internal


### PR DESCRIPTION
Caches are very dangerous, especially when updated later. Ideally they should be as foolproof as possible. Here are a few hacks in that direction -- now each cache entry invalidates its own dependents (easier to maintain this way and less code). All the access methods are private. I can think of some more safety features but this is a start.

WDYT @amcastro-tri?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/amcastro-tri/drake/13)
<!-- Reviewable:end -->
