### PR TITLE
Various docs fixes

### DIFF
--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -326,51 +326,55 @@ externally applied body forces, constraint forces, and contact forces.
 
 In a %MultibodyPlant model an actuator can be added as a JointActuator, see
 AddJointActuator(). The plant declares actuation input ports to provide
-feedforward actuation, see get_actuation_input_port(). Actuation ports can be
-requested for each individual
-@ref model_instances "model instance" in the %MultibodyPlant.
+feedforward actuation, both for the %MultibodyPlant as a whole (see
+get_actuation_input_port()) and for each individual @ref model_instances
+"model instance" in the %MultibodyPlant (see
+@ref get_actuation_input_port(ModelInstanceIndex)const
+"get_actuation_input_port(ModelInstanceIndex)").
+Any actuation input ports not connected are assumed to be zero.
 
-Unless PD controllers are defined
-(see @ref pd_controllers "PD controlled actuators" next), actuation input ports
-are required to be connected.
+@note The vector data supplied to %MultibodyPlant's actuation input ports should
+be ordered by @ref JointActuatorIndex. For the get_actuation_input_port() that
+covers all actuators, the iᵗʰ vector element corresponds to
+`JointActuatorIndex(i)`. For the
+@ref get_actuation_input_port(ModelInstanceIndex)const
+"get_actuation_input_port(ModelInstanceIndex)" specific to a model index, the
+vector data is ordered by monotonically increasing @ref JointActuatorIndex for
+the actuators within that @ref ModelInstanceIndex: the 0ᵗʰ vector element
+corresponds to the lowest-numbered %JointActuatorIndex of that instance, the 1ˢᵗ
+vector element corresponds to the second-lowest-numbered %JointActuatorIndex of
+that instance, etc.
+
+@note The following snipet shows how per model instance actuation can be set:
+```
+ModelInstanceIndex model_instance_index = ...;
+VectorX<T> u_instance(plant.num_actuated_dofs(model_instance_index));
+int offset = 0;
+for (JointActuatorIndex joint_actuator_index :
+         plant.GetJointActuatorIndices(model_instance_index)) {
+  const JointActuator<T>& actuator = plant.get_joint_actuator(
+      joint_actuator_index);
+  const Joint<T>& joint = actuator.joint();
+  VectorX<T> u_joint = ... my_actuation_logic_for(joint) ...;
+  ASSERT(u_joint.size() == joint_actuator.num_inputs());
+  u_instance.segment(offset, u_joint.size()) = u_joint;
+  offset += u_joint.size();
+}
+plant.get_actuation_input_port(model_instance_index).FixValue(
+    plant_context, u_instance);
+```
+
+@note To inter-operate between the whole plant actuation vector and sets of
+per-model instance actuation vectors, see SetActuationInArray() to gather the
+model instance vectors into a whole plant vector and GetActuationFromArray() to
+scatter the whole plant vector into per-model instance vectors.
 
 @warning Effort limits (JointActuator::effort_limit()) are not enforced, unless
-PD controllers are defined. See @ref pd_controllers "PD controlled actuators".
+PD controllers are defined.
+See @ref pd_controllers "Using PD controlled actuators".
 
 <!-- TODO(amcastro-tri): Consider enforcing effort limits whether PD controllers
      are defined or not. -->
-
-@anchor model_instance_actuation
-  #### Actuation per model instance
-
-Actuation can be provided per model instance, using the corresponding actuation
-input port for the specific model instance, see singature of
-get_actuation_input_port() taking a model instance index.
-
-@warning Joint actuator indices are continuous within a %MultibodyPlant model.
-However, indices within a model instance can be sparse. This situation can
-happen when users add joint actuators in arbitrary order after model instances
-were created. For a more typical use of model files (such as URDF or SDF)
-actuator indexes will be continuous within a model instance.
-
-The following snipet shows how per model instance actuation can be set: <pre>
-  VectorXd u_instance(plant.num_actuated_dofs(model_instance_index));
-  int a_instance = 0;
-  for (auto actuator_index :
-    plant.GetJointActuatorIndices(model_instance_index)) {
-      // We might need the actuated joint, for instance, to get the current
-      // state for that joint.
-      const auto& actuator = plant.get_joint_actuator(actuator_index);
-      const auto& joint = actuator.joint();
-      u_instance[a_instance++] = ... // code to set values.
-  }
-</pre>
-`u_instance` can be fed into the port for `model_instace_index`. If instead the
-actuation input port for the full plant is desired, `u_instance` can be
-scattered into a vector for the full plant with SetActuationInArray().
-Similarly, the user might opt for working with the full vector of actuation
-first, and then gatter into per model instance vectors with
-GetActuationFromArray().
 
 @anchor pd_controllers
   #### Using PD controlled actuators
@@ -822,40 +826,25 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   const systems::OutputPort<T>& get_body_spatial_accelerations_output_port()
       const;
 
-  /// Returns a constant reference to the input port for external actuations for
-  /// all actuated dofs. This input port is a vector valued port ordered by
-  /// JointActuatorIndex, see JointActuator::index(), and can be set with
+  /// Returns a constant reference to the input port for external actuation for
+  /// all actuated dofs. This input port is a vector valued port indexed by
+  /// @ref JointActuatorIndex, see JointActuator::index(), and can be set with
   /// JointActuator::set_actuation_vector().
   /// Refer to @ref mbp_actuation "Actuation" for further details.
   /// @pre Finalize() was already called on `this` plant.
   /// @throws std::exception if called before Finalize().
-  /// @throws std::exception if individual actuation ports are connected.
   const systems::InputPort<T>& get_actuation_input_port() const;
 
   /// Returns a constant reference to the input port for external actuation for
-  /// a specific model instance. This is a vector valued port with entries in
-  /// ascending order of JointActuatorIndex within `model_instance`. Refer to
-  /// @ref model_instance_actuation "Actuation per model instance" for further
+  /// a specific model instance. This is a vector valued port with entries
+  /// ordered by monotonically increasing @ref JointActuatorIndex within
+  /// `model_instance`. Refer to @ref mbp_actuation "Actuation" for further
   /// details.
   ///
-  /// Each model instance in `this` plant model has an actuation input port,
-  /// even if zero sized (for model instance with no actuators.)
+  /// Every model instance in `this` plant model has an actuation input port,
+  /// even if zero sized (for model instance with no actuators).
   ///
   /// @see GetJointActuatorIndices(), GetActuatedJointIndices().
-  ///
-  /// @note This is a vector valued port of size num_actuators(model_instance)
-  /// (where we assume only 1-DOF joints are actuated.)
-  ///
-  /// @warning It is required to connect this input port unless the model
-  /// instance has PD controllers defined, see get_desired_state_input_port(),
-  /// or if the full multibody version of this port is connected. For models
-  /// with PD controllers, actuation defaults to zero. This allows the modeler
-  /// to use PD controllers only, without the need to provide feed-forward
-  /// torques.
-  ///
-  /// @warning This port cannot be used together with get_actuation_input_port()
-  /// for the full multibody system. Either use the port for the full multibody
-  /// system or the port per model instance, never both.
   ///
   /// @pre Finalize() was already called on `this` plant.
   /// @throws std::exception if called before Finalize().
@@ -2817,13 +2806,12 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
       bool add_model_instance_prefix = false) const;
 
   /// Returns a vector of actuation values for `model_instance` from a vector
-  /// `u` of actuation values for the entire model. Refer to @ref
-  /// model_instance_actuation "Actuation per model instance" for further
-  /// details.
-  /// @param[in] u Actuation values for the entire model, in increasing order of
-  /// JointActuatorIndex.
-  /// @returns the actuation values for `model_instance`, in increasing order of
-  /// JointActuatorIndex within the model instance.
+  /// `u` of actuation values for the entire plant model. Refer to @ref
+  /// mbp_actuation "Actuation" for further details.
+  /// @param[in] u Actuation values for the entire model, indexed by
+  /// @ref JointActuatorIndex.
+  /// @returns Actuation values for `model_instance`, ordered by monotonically
+  /// increasing @ref JointActuatorIndex.
   /// @throws std::exception if `u` is not of size
   /// MultibodyPlant::num_actuated_dofs().
   VectorX<T> GetActuationFromArray(
@@ -2832,21 +2820,18 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
     return internal_tree().GetActuationFromArray(model_instance, u);
   }
 
-  /// Given the actuation values `u_instance` for all actuators in
-  /// `model_instance`, this method sets the actuation vector u for the entire
-  /// model to which this actuator belongs to. Refer to @ref
-  /// model_instance_actuation "Actuation per model instance" for further
+  /// Given actuation values `u_instance` for the actuators in `model_instance`,
+  /// update the actuation vector u for the entire plant model to which this
+  /// actuator belongs to. Refer to @ref mbp_actuation "Actuation" for further
   /// details.
-  /// @param[in] u_instance Actuation values for the actuators. It must be of
-  ///   size equal to the number of degrees of freedom of all of the actuated
-  ///   joints in `model_instance`. Values are indexed in increasing order of
-  ///   JointActuatorIndex within the model instance.
-  /// @param[out] u
-  ///   The vector containing the actuation values for the entire model. Indexed
-  ///   in increasing order of JointActuatorIndex. On output, only values
-  ///   corresponding to `model_instance` are changed.
+  /// @param[in] u_instance Actuation values for the model instance. Values are
+  ///   ordered by montonically increasing @ref JointActuatorIndex within the
+  ///   model instance.
+  /// @param[in,out] u Actuation values for the entire plant model, indexed by
+  ///   @ref JointActuatorIndex. Only values corresponding to `model_instance`
+  ///   are changed.
   /// @throws std::exeption if the size of `u_instance` is not equal to the
-  /// number of actuated degrees of freedom in `model_instance`.
+  ///   number of actuation inputs for the joints of `model_instance`.
   void SetActuationInArray(
       ModelInstanceIndex model_instance,
       const Eigen::Ref<const VectorX<T>>& u_instance,
@@ -4573,7 +4558,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   }
 
   /// Returns a list of joint actuator indices associated with `model_instance`.
-  /// The returned vector is sorted in ascending order of JointActuatorIndex.
+  /// The list is sorted in ascending order of @ref JointActuatorIndex.
   /// @throws std::exception if called pre-finalize.
   std::vector<JointActuatorIndex> GetJointActuatorIndices(
       ModelInstanceIndex model_instance) const {
@@ -4923,17 +4908,21 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
 
   /// Returns a vector of size `num_actuated_dofs()` containing the lower effort
   /// limits for every actuator. Any unbounded or unspecified limits will be
-  /// -infinity. The returned vector is indexed by JointActuatorIndex, see
+  /// -∞. The returned vector is indexed by @ref JointActuatorIndex, see
   /// JointActuator::index().
+  /// @see GetEffortUpperLimits()
   /// @throws std::exception if called pre-finalize.
   VectorX<double> GetEffortLowerLimits() const {
     DRAKE_MBP_THROW_IF_NOT_FINALIZED();
     return internal_tree().GetEffortLowerLimits();
   }
 
-  /// Upper limit analog of GetEffortLowerLimits(), where any unbounded
-  /// or unspecified limits will be +infinity.
-  /// @see GetEffortLowerLimits() for more information.
+  /// Returns a vector of size `num_actuated_dofs()` containing the upper effort
+  /// limits for every actuator. Any unbounded or unspecified limits will be
+  /// +∞. The returned vector is indexed by @ref JointActuatorIndex, see
+  /// JointActuator::index().
+  /// @see GetEffortLowerLimits()
+  /// @throws std::exception if called pre-finalize.
   VectorX<double> GetEffortUpperLimits() const {
     DRAKE_MBP_THROW_IF_NOT_FINALIZED();
     return internal_tree().GetEffortUpperLimits();
@@ -5171,7 +5160,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   void EstimatePointContactParameters(double penetration_allowance);
 
   // Helper method to assemble actuation input vector from the appropriate
-  // ports. The output vector is ordered by JointActuatorIndex.
+  // ports. The return value is indexed by JointActuatorIndex.
   VectorX<T> AssembleActuationInput(
       const systems::Context<T>& context) const;
 

--- a/multibody/tree/joint_actuator.h
+++ b/multibody/tree/joint_actuator.h
@@ -104,7 +104,7 @@ class JointActuator final : public MultibodyElement<T> {
       MultibodyForces<T>* forces) const;
 
   /// Gets the actuation values for `this` actuator from the actuation vector u
-  /// for the entire model.
+  /// for the entire plant model.
   /// @return a reference to a nv-dimensional vector, where nv is the number
   ///         of velocity variables of joint().
   const Eigen::Ref<const VectorX<T>> get_actuation_vector(
@@ -113,18 +113,18 @@ class JointActuator final : public MultibodyElement<T> {
     return u.segment(topology_.actuator_index_start, joint().num_velocities());
   }
 
-  /// Given the actuation values u_actuator for `this` actuator, this method
-  /// sets the actuation vector u for the entire multibody model to which this
-  /// actuator belongs to.
+  /// Given the actuation values `u_actuator` for `this` actuator, updates the
+  /// actuation vector `u` for the entire multibody model to which this actuator
+  /// belongs to.
   /// @param[in] u_actuator
   ///   Actuation values for `this` actuator. It must be of size equal to the
   ///   number of degrees of freedom of the actuated Joint, see
   ///   Joint::num_velocities(). For units and sign conventions refer to the
   ///   specific Joint sub-class documentation.
-  /// @param[out] u
-  ///   The vector containing the actuation values for the entire model to which
-  ///   `this` actuator belongs to. Entries in this vector are in asscending
-  ///   order by JointActuatorIndex.
+  /// @param[in,out] u
+  ///   Actuation values for the entire plant model to which `this` actuator
+  ///   belongs to, indexed by JointActuatorIndex. Only values corresponding to
+  ///   this actuator are changed.
   /// @throws std::exception if
   ///   `u_actuator.size() != this->joint().num_velocities()`.
   /// @throws std::exception if u is nullptr.

--- a/multibody/tree/model_instance.h
+++ b/multibody/tree/model_instance.h
@@ -79,9 +79,8 @@ class ModelInstance : public MultibodyElement<T> {
     mobilizers_.push_back(mobilizer);
   }
 
-  // Adds an actuator to this model insance.
-  // Actuators must be added in asscending order of JointActuator index,
-  // otherwise this method throws an exception.
+  // Adds an actuator to this model insance. Actuators must be added in
+  // monotonically increasing order of JointActuatorIndex (or else throws).
   void add_joint_actuator(const JointActuator<T>* joint_actuator) {
     DRAKE_THROW_UNLESS(joint_actuator != nullptr);
     num_actuated_dofs_ += joint_actuator->joint().num_velocities();
@@ -98,36 +97,33 @@ class ModelInstance : public MultibodyElement<T> {
 
   std::vector<JointIndex> GetActuatedJointIndices() const;
 
-  // Returns an Eigen vector of the actuation for `this` model instance from a
-  // vector `u` of actuator forces for the entire model.
-  // @param[in] u Actuation for the full multibody model, ordered by
+  // Returns the actuation for `this` model instance extracted from `u`.
+  // @param[in] u Actuation for the full plant model, indexed by
   // JointActuatorIndex.
-  // @returns the per model instance actuation, indexed by increasing order of
-  // JointActuatorIndex within this model instance.
+  // @returns the per model instance actuation, order by monotonically
+  // increasing JointActuatorIndex within this model instance.
   // @throws std::exception if `u` is not of size
   //         MultibodyTree::num_actuators().
   VectorX<T> GetActuationFromArray(
       const Eigen::Ref<const VectorX<T>>& u) const;
 
   // Given the actuation values `u_instance` for all actuators in `this` model
-  // instance, this method sets the portion of the actuation vector `u` (which
-  // is the actuation vector for the entire MultibodyTree) corresponding to the
-  // actuators for this model instance.
-  // @param[in] u_instance Actuation values for the actuators. It must be of
-  //   size equal to the number of degrees of freedom of all of the actuated
-  //   joints in this model instance. It is indexed by increasing order of
+  // instance, updates the portion of the actuation vector `u` corresponding to
+  // the actuators for this model instance.
+  // @param[in] u_instance Actuation values for this model instance. It must be
+  //   of size equal to the number of degrees of freedom of all of the actuated
+  //   joints in this model instance. It is ordered by monotonically increasing
   //   JointActuatorIndex within this model instance.
-  // @param[out] u
-  //   The vector containing the actuation values for the entire
-  //   model to which `this` actuator belongs to. It must be of size equal to
-  //   the number of degrees of freedom of all of the actuated joints in the
-  //   entire MultibodyTree model. Indexed by JointActuatorIndex. On output,
-  //   only values corresponding to this model instance are set.
-  // @throws std::exception if `u_instance` is not of size equal to the
-  //         number of degrees of freedom of all of the actuated joints in this
-  //         model or `u` is not of size equal to the number of degrees of
-  //         freedom of all of the actuated joints in the entire MultibodyTree
-  //         model to which `this` actuator belongs to.
+  // @param[in,out] u Actuation values for the entire plant model to which
+  //   `this` actuator belongs, indexed by JointActuatorIndex. It must be of
+  //   size equal to the number of degrees of freedom of all of the actuated
+  //   joints in the entire MultibodyTree model. Only values corresponding to
+  //   this model instance are updated.
+  // @throws std::exception if `u_instance` is not of size equal to the number
+  //   of degrees of freedom of all of the actuated joints in this model or `u`
+  //   is not of size equal to the number of degrees of freedom of all of the
+  //   actuated joints in the entire MultibodyTree model to which `this`
+  //   actuator belongs to.
   void SetActuationInArray(
       const Eigen::Ref<const VectorX<T>>& u_instance,
       EigenPtr<VectorX<T>> u) const;


### PR DESCRIPTION
https://github.com/RobotLocomotion/drake/pull/20212

Rewrite MbP overview text and example.
Fix example code vs multi-dof actuators.
Omg never use `auto` in example code.

Adjust some docs to reflect the new "assume zero" contract, instead of the "barf" contract.

Generally use "monotonically increasing" vs "acending"; "asending" is too easily misinterpreted as incremting by +1 each time.

When referring to full-plant vectors, never say "ordered by JointActuatorIndex" always say "indexed by JointActuatorIndex".

Generally try to clean up superfluous wording like "returns a vector" when the return type is already sitting right there in our face.

Try to say "plant model" instead of just "model" to highlight places where we're talking about the whole plant, vs a single model instance.

Use Doxygen preview to make things look nice.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/amcastro-tri/drake/14)
<!-- Reviewable:end -->
